### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@
 
 Async MCP server for running long-running AI tasks with real-time progress monitoring using [@just-every/task](https://github.com/just-every/task).
 
+<a href="https://glama.ai/mcp/servers/@just-every/mcp-task">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@just-every/mcp-task/badge" alt="Task MCP server" />
+</a>
+
 ## Quick Start
 
 ### 1. Create or use an environment file


### PR DESCRIPTION
This PR adds a badge for the [MCP Task](https://glama.ai/mcp/servers/@just-every/mcp-task) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@just-every/mcp-task">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@just-every/mcp-task/badge" alt="Task MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.